### PR TITLE
外部キーの制約順序変更

### DIFF
--- a/app/config/database.php
+++ b/app/config/database.php
@@ -61,7 +61,7 @@ return [
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
             'prefix_indexes' => true,
-            'strict' => true,
+            'strict' => false,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),

--- a/app/database/migrations/2020_07_11_041153_create_profiles_table.php
+++ b/app/database/migrations/2020_07_11_041153_create_profiles_table.php
@@ -16,7 +16,11 @@ class CreateProfilesTable extends Migration
         Schema::create('profiles', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
-            $table->foreignId('author_id')->constrained('authors');
+            // $table->unsignedBigInteger('author_id')->unique();
+            // $table->foreign('author_id')->references('id')->on('authors'); //外部キー参照
+
+            // Laravel 7.x系の外部キーエイリアスではuniqueを先に設定しないと一意の制約がかからない
+            $table->foreignId('author_id')->unique()->constrained();
         });
     }
 


### PR DESCRIPTION
 // Laravel 7.x系の外部キーエイリアスではuniqueを先に設定しないと一意の制約がかからない
$table->foreignId('author_id')->unique()->constrained();

 // こうするとunique制約がかからない
$table->foreignId('author_id')->constrained()->unique();